### PR TITLE
remove engines.node in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,9 +36,6 @@
     "eslint-plugin-react": "^6.3.0",
     "webpack": "^1.8.11"
   },
-  "engines": {
-    "node": ">= 5.11.0"
-  },
   "author": "InJung Chung <mu29@yeoubi.net>",
   "license": "MIT",
   "dependencies": {


### PR DESCRIPTION
안녕하세요, 좋은 오픈소스 감사합니다!

nodejs 4점대 버전을 사용하여 프로젝트를 진행중인데,
package.json 파일에 아래와같이 nodejs 버전 명시가 되어있어서 npm 에서 받는 버전을 바로 사용을 못하고 있습니다.

```
  "engines": {
    "node": ">= 5.11.0"
  },
```

이 라이브러리는 브라우저에서 사용되어 nodejs 버전은 체크하지 않아도 될것 같습니다.
물론 babel 을 통해 transform 될 때 nodejs 가 사용되긴 하지만,
이땐 babel 엔진이 호환되는 nodejs 버전을 체크하고 있을것입니다.

engines.node 를 제거하여 PR 드리니 버전 업 후 npm registry 에도 publish 해주시면 감사하겠습니다.