### PR TITLE
Feature/disabled prop type

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Well-designed radio buttons for react
 ## Installation
 ```
 npm install react-radio-buttons --save
-``` 
+```
 Then just add `import { RadioGroup, RadioButton } from 'react-radio-buttons';` into your file.
 
 ## Screenshot
@@ -36,7 +36,7 @@ By using `react-radio-buttons`, you can write like this (full example [here](htt
 
 ## API
 ### RadioGroup
-| name     | description    | 
+| name     | description    |
 |----------|----------------|
 |onChange|called when select child `RadionButton`|
 |value|initial selected value|
@@ -44,7 +44,7 @@ By using `react-radio-buttons`, you can write like this (full example [here](htt
 |chlidren|define your `RadioButton`s|
 
 ### RadioButton
-| name     | description    | 
+| name     | description    |
 |----------|----------------|
 |iconSize|size of `RadioIcon`, which appear right side of button|
 |iconInnerSize|size of `RadioIcon` 's inner icon when selected, **proper value is same as iconSize or half of iconSize**|
@@ -53,6 +53,8 @@ By using `react-radio-buttons`, you can write like this (full example [here](htt
 |pointColor|color when selected|
 |value|return value when selected|
 |children|prefer string|
+|disabled|boolean flag that allows you to disable a certain a button|
+|disabledColor|color when disabled, including the `RadioIcon`|
 
 ## Author
 

--- a/example/example.jsx
+++ b/example/example.jsx
@@ -35,6 +35,19 @@ let App = React.createClass({
             Melon
           </RadioButton>
         </RadioGroup>
+        <h4 style={ { marginTop: 32 } }>1st option disabled (prevents onChange callback and style overwrite to look disabled)</h4>
+        <RadioGroup onChange={ this.onChange }>
+          <RadioButton value="apple" disabled={true}>
+            Apple
+          </RadioButton>
+          <RadioButton value="orange">
+            Orange
+          </RadioButton>
+          <RadioButton value="melon">
+            Melon
+          </RadioButton>
+        </RadioGroup>
+        <h4>Check console to see the value of the RadioGroup via the onChange callback</h4>
       </div>
     );
   }

--- a/example/example.jsx
+++ b/example/example.jsx
@@ -37,7 +37,7 @@ let App = React.createClass({
         </RadioGroup>
         <h4 style={ { marginTop: 32 } }>1st option disabled (prevents onChange callback and style overwrite to look disabled)</h4>
         <RadioGroup onChange={ this.onChange }>
-          <RadioButton value="apple" disabled={true}>
+          <RadioButton value="apple" disabled={true} disabledColor={'green'}>
             Apple
           </RadioButton>
           <RadioButton value="orange">

--- a/index.jsx
+++ b/index.jsx
@@ -78,15 +78,15 @@ export class RadioButton extends Component {
   }
 
   getStyles() {
-    const { horizontal, last, padding, rootColor, pointColor, disabled } = this.props;
+    const { horizontal, last, padding, rootColor, pointColor, disabled, disabledColor } = this.props;
 
     return {
       root: {
         cursor: disabled ? 'not-allowed' : 'pointer',
-        color: disabled ? '#e1e1e1' : (rootColor || '#E0E0E0'),
+        color: disabled ? (disabledColor || '#e1e1e1') : (rootColor || '#E0E0E0'),
         borderWidth: 1,
         borderStyle: 'solid',
-        borderColor: rootColor || '#E0E0E0',
+        borderColor: disabled ? (disabledColor || '#e1e1e1') : (rootColor || '#E0E0E0'),
         borderRadius: 1,
         padding: padding || 16,
         flex: 1,
@@ -106,7 +106,7 @@ export class RadioButton extends Component {
   }
 
   render() {
-    const { checked, iconSize, iconInnerSize, rootColor, pointColor, children, disabled } = this.props;
+    const { checked, iconSize, iconInnerSize, rootColor, pointColor, children, disabled, disabledColor } = this.props;
     const style = this.getStyles();
     const buttonStyle = Object.assign(style.root, checked ? style.checked : {});
     return (
@@ -117,7 +117,7 @@ export class RadioButton extends Component {
           </div>
           <RadioIcon size={ iconSize } innerSize={ iconInnerSize }
             checked={ checked } rootColor={ rootColor } pointColor={ pointColor }
-            disabled={ disabled }
+            disabled={ disabled } disabledColor={ disabledColor }
           />
         </div>
       </div>
@@ -137,7 +137,8 @@ RadioButton.propTypes = {
   children: PropTypes.node,
   horizontal: PropTypes.bool,
   onChange: PropTypes.func,
-  disabled: PropTypes.bool
+  disabled: PropTypes.bool,
+  disabledColor: PropTypes.bool
 };
 
 class RadioIcon extends Component {
@@ -147,7 +148,7 @@ class RadioIcon extends Component {
   }
 
   getStyles() {
-    const { size, innerSize, rootColor, pointColor, disabled } = this.props;
+    const { size, innerSize, rootColor, pointColor, disabled, disabledColor } = this.props;
 
     return {
       root: {
@@ -158,7 +159,7 @@ class RadioIcon extends Component {
         borderWidth: 2,
         borderRadius: '50%',
         borderStyle: 'solid',
-        borderColor: disabled ? '#e1e1e1' : (rootColor || '#9E9E9E'),
+        borderColor: disabled ? (disabledColor || '#e1e1e1') : (rootColor || '#9E9E9E'),
       },
       checked: {
         borderColor: pointColor || '#8CB9FD',
@@ -190,5 +191,6 @@ RadioIcon.propTypes = {
   rootColor: PropTypes.string,
   pointColor: PropTypes.string,
   checked: PropTypes.bool,
-  disabled: PropTypes.bool
+  disabled: PropTypes.bool,
+  disabledColor: PropTypes.string
 };

--- a/index.jsx
+++ b/index.jsx
@@ -1,10 +1,24 @@
 import React, { Component, PropTypes } from 'react';
 
+function getInitialCheckedIndex(children) {
+    let checkedIndex;
+
+    for (let i = 0; i < children.length; i++) {
+      if (!children[i].props.disabled) {
+          console.log(children[i]);
+          checkedIndex = i;
+          break;
+      }
+    }
+
+    return checkedIndex;
+}
+
 export class RadioGroup extends Component {
   constructor({ children, value }) {
     super();
     const index = children.findIndex(c => c.props.value === value);
-    this.state = { checkedIndex: index > -1 ? index : 0 };
+    this.state = { checkedIndex: (index > -1 && !children[index].disabled) ? index : getInitialCheckedIndex(children) };
     this.renderChild = this.renderChild.bind(this);
     this.onChange = this.onChange.bind(this);
   }
@@ -64,10 +78,12 @@ export class RadioButton extends Component {
   }
 
   getStyles() {
-    const { horizontal, last, padding, rootColor, pointColor } = this.props;
+    const { horizontal, last, padding, rootColor, pointColor, disabled } = this.props;
 
     return {
       root: {
+        cursor: disabled ? 'not-allowed' : 'pointer',
+        color: disabled ? '#e1e1e1' : (rootColor || '#E0E0E0'),
         borderWidth: 1,
         borderStyle: 'solid',
         borderColor: rootColor || '#E0E0E0',
@@ -85,12 +101,12 @@ export class RadioButton extends Component {
   }
 
   onClick() {
-    const { onChange, checked, index } = this.props;
-    onChange && onChange(index);
+    const { onChange, checked, index, disabled } = this.props;
+    !disabled && onChange && onChange(index);
   }
 
   render() {
-    const { checked, iconSize, iconInnerSize, rootColor, pointColor, children } = this.props;
+    const { checked, iconSize, iconInnerSize, rootColor, pointColor, children, disabled } = this.props;
     const style = this.getStyles();
     const buttonStyle = Object.assign(style.root, checked ? style.checked : {});
     return (
@@ -99,8 +115,9 @@ export class RadioButton extends Component {
           <div style={ { flex: 1 } }>
             { children }
           </div>
-          <RadioIcon size={ iconSize } innerSize={ iconInnerSize } 
+          <RadioIcon size={ iconSize } innerSize={ iconInnerSize }
             checked={ checked } rootColor={ rootColor } pointColor={ pointColor }
+            disabled={ disabled }
           />
         </div>
       </div>
@@ -120,6 +137,7 @@ RadioButton.propTypes = {
   children: PropTypes.node,
   horizontal: PropTypes.boolean,
   onChange: PropTypes.func,
+  disabled: PropTypes.boolean
 };
 
 class RadioIcon extends Component {
@@ -129,8 +147,8 @@ class RadioIcon extends Component {
   }
 
   getStyles() {
-    const { size, innerSize, rootColor, pointColor } = this.props;
-    
+    const { size, innerSize, rootColor, pointColor, disabled } = this.props;
+
     return {
       root: {
         width: size || 10,
@@ -140,7 +158,7 @@ class RadioIcon extends Component {
         borderWidth: 2,
         borderRadius: '50%',
         borderStyle: 'solid',
-        borderColor: rootColor || '#9E9E9E',
+        borderColor: disabled ? '#e1e1e1' : (rootColor || '#9E9E9E'),
       },
       checked: {
         borderColor: pointColor || '#8CB9FD',
@@ -172,4 +190,5 @@ RadioIcon.propTypes = {
   rootColor: PropTypes.string,
   pointColor: PropTypes.string,
   checked: PropTypes.boolean,
+  disabled: PropTypes.boolean
 };


### PR DESCRIPTION
I have added a `disabled` prop type that you can apply to a `<RadioButton>`  component as a means to disable selection of that button. 

By adding a prop of `disabled={true}`, that `<RadioButton>` will no longer trigger the onChange event when clicked and will have some basic "disabled" styles added to it: `cursor: not-allowed` and a light grey `color` and `border-color` treatment.

Please see example.html for implementation and request any changes after review.

Thank you!