### PR TITLE
Feature/#11 set no default value

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ By using `react-radio-buttons`, you can write like this (full example [here](htt
 | name     | description    |
 |----------|----------------|
 |onChange|called when select child `RadionButton`|
-|value|initial selected value|
+|value|initial selected value, omit for no selection and set to `''` for first enabled control|
 |horizontal|whether align horizontally|
 |chlidren|define your `RadioButton`s|
 

--- a/index.jsx
+++ b/index.jsx
@@ -16,8 +16,20 @@ function getInitialCheckedIndex(children) {
 export class RadioGroup extends Component {
   constructor({ children, value }) {
     super();
-    const index = children.findIndex(c => c.props.value === value);
-    this.state = { checkedIndex: (index > -1 && !children[index].disabled) ? index : getInitialCheckedIndex(children) };
+
+    const selectedIndex = children.findIndex(c => c.props.selected && !c.props.disabled);
+    const valueIndex = children.findIndex(c => c.props.value === value && !c.props.disabled);
+    let checkedIndex = -1;
+
+    if (selectedIndex > -1) {
+      checkedIndex = selectedIndex;
+    } else if (valueIndex > -1) {
+      checkedIndex = valueIndex;
+    } else {
+        checkedIndex = getInitialCheckedIndex(children);
+    }
+
+    this.state = { checkedIndex:  checkedIndex };
     this.renderChild = this.renderChild.bind(this);
     this.onChange = this.onChange.bind(this);
   }
@@ -138,7 +150,8 @@ RadioButton.propTypes = {
   horizontal: PropTypes.bool,
   onChange: PropTypes.func,
   disabled: PropTypes.bool,
-  disabledColor: PropTypes.string
+  disabledColor: PropTypes.string,
+  selected: PropTypes.bool
 };
 
 export class ReversedRadioButton extends Component {

--- a/index.jsx
+++ b/index.jsx
@@ -1,35 +1,28 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 
 function getInitialCheckedIndex(children) {
-    let checkedIndex;
+  let checkedIndex;
 
-    for (let i = 0; i < children.length; i++) {
-      if (!children[i].props.disabled) {
-          checkedIndex = i;
-          break;
-      }
+  for (let i = 0; i < children.length; i++) {
+    if (!children[i].props.disabled) {
+      checkedIndex = i;
+      break;
     }
+  }
 
-    return checkedIndex;
+  return checkedIndex;
 }
 
 export class RadioGroup extends Component {
   constructor({ children, value }) {
     super();
 
-    const selectedIndex = children.findIndex(c => c.props.selected && !c.props.disabled);
-    const valueIndex = children.findIndex(c => c.props.value === value && !c.props.disabled);
-    let checkedIndex = -1;
+    const index = children.findIndex(c => c.props.value === value);
+    const checkedIndex = !(value !== undefined || value === '') ? -1 : (index > -1 && !children[index].props.disabled) ? index : getInitialCheckedIndex(children)
+    
+    this.state = { checkedIndex: checkedIndex };
 
-    if (selectedIndex > -1) {
-      checkedIndex = selectedIndex;
-    } else if (valueIndex > -1) {
-      checkedIndex = valueIndex;
-    } else {
-        checkedIndex = getInitialCheckedIndex(children);
-    }
-
-    this.state = { checkedIndex:  checkedIndex };
     this.renderChild = this.renderChild.bind(this);
     this.onChange = this.onChange.bind(this);
   }
@@ -66,7 +59,7 @@ export class RadioGroup extends Component {
     const { horizontal, children, ...props } = this.props;
     const style = horizontal ? { display: 'inline-flex', width: '100%' } : {};
     return (
-      <div style={ style } {...props}>
+      <div style={style} {...props}>
         {
           children.map((c, i) => (this.renderChild(c, i, i === checkedIndex)))
         }
@@ -122,14 +115,14 @@ export class RadioButton extends Component {
     const style = this.getStyles();
     const buttonStyle = Object.assign(style.root, checked ? style.checked : {});
     return (
-      <div style={ buttonStyle } onClick={ this.onClick }>
-        <div style={ { display: 'inline-flex', width: '100%' } }>
-          <div style={ { flex: 1 } }>
-            { children }
+      <div style={buttonStyle} onClick={this.onClick}>
+        <div style={{ display: 'inline-flex', width: '100%' }}>
+          <div style={{ flex: 1 }}>
+            {children}
           </div>
-          <RadioIcon size={ iconSize } innerSize={ iconInnerSize }
-            checked={ checked } rootColor={ rootColor } pointColor={ pointColor }
-            disabled={ disabled } disabledColor={ disabledColor }
+          <RadioIcon size={iconSize} innerSize={iconInnerSize}
+            checked={checked} rootColor={rootColor} pointColor={pointColor}
+            disabled={disabled} disabledColor={disabledColor}
           />
         </div>
       </div>
@@ -150,8 +143,7 @@ RadioButton.propTypes = {
   horizontal: PropTypes.bool,
   onChange: PropTypes.func,
   disabled: PropTypes.bool,
-  disabledColor: PropTypes.string,
-  selected: PropTypes.bool
+  disabledColor: PropTypes.string
 };
 
 export class ReversedRadioButton extends Component {
@@ -194,15 +186,15 @@ export class ReversedRadioButton extends Component {
     const style = this.getStyles();
     const buttonStyle = Object.assign(style.root, checked ? style.checked : {});
     return (
-      <div style={ buttonStyle } onClick={ this.onClick }>
-        <div style={ { display: 'inline-flex', width: '100%' } }>
-          <RadioIcon size={ iconSize } innerSize={ iconInnerSize }
-            checked={ checked } rootColor={ rootColor } pointColor={ pointColor }
-            disabled={ disabled } disabledColor={ disabledColor }
-            marginRight={ padding || 16 }
+      <div style={buttonStyle} onClick={this.onClick}>
+        <div style={{ display: 'inline-flex', width: '100%' }}>
+          <RadioIcon size={iconSize} innerSize={iconInnerSize}
+            checked={checked} rootColor={rootColor} pointColor={pointColor}
+            disabled={disabled} disabledColor={disabledColor}
+            marginRight={padding || 16}
           />
-          <div style={ { flex: 1 } }>
-            { children }
+          <div style={{ flex: 1 }}>
+            {children}
           </div>
         </div>
       </div>
@@ -264,8 +256,8 @@ export class RadioIcon extends Component {
     const style = this.getStyles();
     const iconStyle = Object.assign(style.root, checked ? style.checked : {});
     return (
-      <div style={ iconStyle }>
-        { checked && <div style={ style.inner } /> }
+      <div style={iconStyle}>
+        {checked && <div style={style.inner} />}
       </div>
     );
   }

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
   "author": "InJung Chung <mu29@yeoubi.net>",
   "license": "MIT",
   "dependencies": {
+    "prop-types": "^15.5.10",
     "react": "^15.3.2",
     "react-dom": "^15.3.2"
   }


### PR DESCRIPTION
I need to have no option selected on the first form load. I have changed the logic slightly.

For a given `RadioGroup`:
- `value` is omitted will have no selected
- `value` is empty or not valid will select first enabled `RadioButton`
- `value` is a valid and enabled `RadioButton` will select that control
- `value` is a valid and disabled `RadioButton` will select first enabled `RadioButton`

This is the best I could do. I think that we should move away from a group level value and set a `checked` or `selected` attribute on the `RadioButton` similar to how an HTML radio button works. That's a bigger change than this, so I will leave it with the owner to consider.