### PR TITLE
update disabledColor prop checking to string

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -421,7 +421,7 @@ ReversedRadioButton.propTypes = {
   horizontal: _propTypes2.default.bool,
   onChange: _propTypes2.default.func,
   disabled: _propTypes2.default.bool,
-  disabledColor: _propTypes2.default.bool,
+  disabledColor: _propTypes2.default.string,
   label: _propTypes2.default.string
 };
 


### PR DESCRIPTION
Hi there, the `ReversedRadioButton` with a particular `disabledColor` property set was breaking because it was looking for a bool. Thought I would just make a quick PR for you, thanks for the great library! :-)